### PR TITLE
Add references to require() of ESM warning

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -968,10 +968,10 @@ Module._extensions['.js'] = function(module, filename) {
     if (pkg && pkg.type === 'module') {
       if (warnRequireESM) {
         process.emitWarning(
-          'require() of .js files inside of a package with "type": "module" ' +
-          'in its package.json is not supported under --experimental-modules' +
-          '\nRather use import to load this module, or if you are the author' +
-          ' you may want to use the .cjs extension for this file.'
+          'require() of .js file ' + filename + ' is not supported as it is ' +
+          'an ES module due to having "type": "module" in its package.json ' +
+          'file.\nRather use import to load this module, or if you are the ' +
+          'author you may want to use the .cjs extension for this file.'
         );
         warnRequireESM = false;
       }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -960,13 +960,24 @@ Module.prototype._compile = function(content, filename) {
   return result;
 };
 
-
 // Native extension for .js
+let warnRequireESM = true;
 Module._extensions['.js'] = function(module, filename) {
-  if (experimentalModules && filename.endsWith('.js')) {
+  if (filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
     if (pkg && pkg.type === 'module') {
-      throw new ERR_REQUIRE_ESM(filename);
+      if (warnRequireESM) {
+        process.emitWarning(
+          'require() of .js files inside of a package with "type": "module" ' +
+          'in its package.json is not supported under --experimental-modules' +
+          '\nRather use import to load this module, or if you are the author' +
+          ' you may want to use the .cjs extension for this file.'
+        );
+        warnRequireESM = false;
+      }
+      if (experimentalModules) {
+        throw new ERR_REQUIRE_ESM(filename);
+      }
     }
   }
   const content = fs.readFileSync(filename, 'utf8');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -260,7 +260,10 @@ function readPackageScope(checkPath) {
     if (checkPath.endsWith(path.sep + 'node_modules'))
       return false;
     const pjson = readPackage(checkPath);
-    if (pjson) return pjson;
+    if (pjson) return {
+      path: checkPath,
+      data: pjson
+    };
   }
   return false;
 }
@@ -965,13 +968,18 @@ let warnRequireESM = true;
 Module._extensions['.js'] = function(module, filename) {
   if (filename.endsWith('.js')) {
     const pkg = readPackageScope(filename);
-    if (pkg && pkg.type === 'module') {
+    if (pkg && pkg.data && pkg.data.type === 'module') {
       if (warnRequireESM) {
         process.emitWarning(
-          'require() of .js file ' + filename + ' is not supported as it is ' +
-          'an ES module due to having "type": "module" in its package.json ' +
-          'file.\nRather use import to load this module, or if you are the ' +
-          'author you may want to use the .cjs extension for this file.'
+          ((module.parent && module.parent.filename) ?
+            `${module.parent.filename} contains a ` : '') +
+          `require() of ${filename}, which is a .js file whose nearest ` +
+          'parent package.json contains "type": "module" which therefore ' +
+          'defines all .js files in that package scope as ES modules. ' +
+          'require() of ES modules is not allowed. Instead, rename ' +
+          `${filename} to end in .cjs, or change the requiring code to use ` +
+          'import(), or remove "type": "module" from ' +
+          `${path.resolve(pkg.path, 'package.json')}.`
         );
         warnRequireESM = false;
       }

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -17,8 +17,8 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
   assert.strictEqual(stderr, `(node:${child.pid}) Warning: require() of .js ` +
-      'files inside of a package with "type": "module" in its package.json ' +
-      'is not supported under --experimental-modules\nRather use import to ' +
-      'load this module, or if you are the author you may want to use the ' +
-      '.cjs extension for this file.\n');
+      `file ${entry} is not supported as it is an ES module due to having ` +
+      '"type": "module" in its package.json file.\nRather use import to load ' +
+      'this module, or if you are the author you may want to use the .cjs ' +
+      'extension for this file.\n');
 }));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const assert = require('assert');
+const path = require('path');
 
 const entry = fixtures.path('/es-modules/cjs-esm.js');
 
@@ -17,8 +18,8 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
   assert.strictEqual(stderr, `(node:${child.pid}) Warning: require() of .js ` +
-      `file ${entry} is not supported as it is an ES module due to having ` +
-      '"type": "module" in its package.json file.\nRather use import to load ' +
-      'this module, or if you are the author you may want to use the .cjs ' +
-      'extension for this file.\n');
+      `file ${path.resolve(entry, '../package-type-module/cjs.js')} is not ` +
+      'supported as it is an ES module due to having "type": "module" in its ' +
+      'package.json file.\nRather use import to load this module, or if you ' +
+      'are the author you may want to use the .cjs extension for this file.\n');
 }));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+const entry = fixtures.path('/es-modules/cjs-esm.js');
+
+const child = spawn(process.execPath, [entry]);
+let stderr = '';
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (data) => {
+  stderr += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stderr, `(node:${child.pid}) Warning: require() of .js ` +
+      'files inside of a package with "type": "module" in its package.json ' +
+      'is not supported under --experimental-modules\nRather use import to ' +
+      'load this module, or if you are the author you may want to use the ' +
+      '.cjs extension for this file.\n');
+}));

--- a/test/fixtures/es-modules/cjs-esm.js
+++ b/test/fixtures/es-modules/cjs-esm.js
@@ -1,0 +1,1 @@
+require('./package-type-module/cjs.js');

--- a/test/fixtures/es-modules/package-type-module/cjs.js
+++ b/test/fixtures/es-modules/package-type-module/cjs.js
@@ -1,0 +1,1 @@
+module.exports = 'asdf';


### PR DESCRIPTION
This changes the warning to a message like:

```
(node:90383) Warning: /Users/geoffrey/Sites/node/test/fixtures/es-modules/cjs-esm.js
contains a require() of /Users/geoffrey/Sites/node/test/fixtures/es-modules/
package-type-module/cjs.js, which is a .js file whose nearest parent package.json 
contains "type": "module" which therefore defines all .js files in that package scope
as ES modules. require() of ES modules is not allowed. Instead, rename 
/Users/geoffrey/Sites/node/test/fixtures/es-modules/package-type-module/cjs.js to end
in .cjs, or change the requiring code to use import(), or remove "type": "module" from
/Users/geoffrey/Sites/node/test/fixtures/es-modules/package-type-module/package.json.
```